### PR TITLE
Fix caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,7 +151,6 @@ def verify_mailchimp_credentials(api_key: str, server_prefix: str) -> bool:
         st.error(f"An unexpected error occurred: {e}")
         return False
 
-@st.cache_data(show_spinner="Fetching lists from Mailchimp...")
 def fetch_mailchimp_lists(_client: Client) -> dict[str, Any]:
     return _client.lists.get_all_lists() # note the usage of the underscore, so streamlit doesn't try to cache the client object(unhashable)
 

--- a/app.py
+++ b/app.py
@@ -151,8 +151,8 @@ def verify_mailchimp_credentials(api_key: str, server_prefix: str) -> bool:
         st.error(f"An unexpected error occurred: {e}")
         return False
 
-def fetch_mailchimp_lists(_client: Client) -> dict[str, Any]:
-    return _client.lists.get_all_lists() # note the usage of the underscore, so streamlit doesn't try to cache the client object(unhashable)
+def fetch_mailchimp_lists(client: Client) -> dict[str, Any]:
+    return client.lists.get_all_lists() # note the usage of the underscore, so streamlit doesn't try to cache the client object(unhashable)
 
 def send_to_mailchimp(df: pd.DataFrame, client: Client):
     """Send categorized leads to Mailchimp"""
@@ -216,7 +216,7 @@ if uploaded_file:
         st.download_button("Download CSV file", csv, "real-intent-mailchimp-leads.csv", "text/csv")
     
     elif user_choice == "Send to Mailchimp" and mailchimp_ready:
-        lists_data = fetch_mailchimp_lists(_client=get_mailchimp_client(api_key, server_prefix))
+        lists_data = fetch_mailchimp_lists(client=get_mailchimp_client(api_key, server_prefix))
         if lists_data:
             audience_options = {lst['name']: lst['id'] for lst in lists_data['lists']}
             list_name = st.selectbox("Select a List", list(audience_options.keys()))

--- a/app.py
+++ b/app.py
@@ -152,7 +152,7 @@ def verify_mailchimp_credentials(api_key: str, server_prefix: str) -> bool:
         return False
 
 def fetch_mailchimp_lists(client: Client) -> dict[str, Any]:
-    return client.lists.get_all_lists() # note the usage of the underscore, so streamlit doesn't try to cache the client object(unhashable)
+    return client.lists.get_all_lists()
 
 def send_to_mailchimp(df: pd.DataFrame, client: Client):
     """Send categorized leads to Mailchimp"""


### PR DESCRIPTION
- lists were being shared across user sessions. Most likely because this method call was being cached, BUT the client object argument wasn't able to be cached(unhashable). This caused the data to 'leak' between users. Temporary fix was to just stop caching fetch_mailchimp_lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated parameter naming for improved clarity in Mailchimp list fetching.
  - Removed loading spinner message when fetching lists from Mailchimp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->