### PR TITLE
Custom Tagger Class

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from typing import Any
 from mailchimp_marketing import Client
 from mailchimp_marketing.api_client import ApiClientError
 
-from lead_tagger import BaseTagger, StandardTagger
+from lead_tagger import BaseTagger, StandardTagger, Custom_1_Tagger
 
 from streamlit_sortables import sort_items
 
@@ -165,8 +165,8 @@ def send_to_mailchimp(df: pd.DataFrame, client: Client):
 
 # -- Tagging Functions --
 @st.cache_data
-def tag_leads(df, tag_mapping, tagger_cls=StandardTagger) -> pd.DataFrame:
-    tagger = tagger_cls(df, tag_mapping)
+def tag_leads(df: pd.DataFrame, tag_mapping: dict[str, list[str]], tagger_cls: BaseTagger = StandardTagger, priority_list: list[str] | None = None) -> pd.DataFrame:
+    tagger = tagger_cls(df, tag_mapping, priority_list)
     return tagger.apply_tags()
 
 
@@ -246,7 +246,7 @@ if uploaded_file:
         tagging_options = st.radio("Tagging Options", ["Standard Tagger", "Custom Tagger #1"], index=0)
         
         st.write(f"{tagging_options}: {BaseTagger.get_description(tagging_options)}")
-        
+                
         if tagging_options == "Standard Tagger":
             tagged_df = tag_leads(df, tag_mapping, StandardTagger)
         elif tagging_options == "Custom Tagger #1":
@@ -263,8 +263,8 @@ if uploaded_file:
             if not sorted_priority:
                 st.warning("Please input at least one mapping to continue.")
                 st.stop()
-
-            tagged_df = tag_leads(df, tag_mapping, StandardTagger)
+            
+            tagged_df = tag_leads(df, tag_mapping, Custom_1_Tagger, sorted_priority)
 
 
         # hoist email, tags, name to first columns

--- a/app.py
+++ b/app.py
@@ -7,6 +7,9 @@ from mailchimp_marketing.api_client import ApiClientError
 
 from lead_tagger import BaseTagger, StandardTagger
 
+from streamlit_sortables import sort_items
+
+
 
 # -- Constants --
 default_columns = [
@@ -240,12 +243,29 @@ if uploaded_file:
                 tags_list = [tag.strip() for tag in tags_input.split(",")]
                 tag_mapping[col] = tags_list
         
-        tagging_options = st.radio("Tagging Options", ["Standard Tagger"], index=0)
+        tagging_options = st.radio("Tagging Options", ["Standard Tagger", "Custom Tagger #1"], index=0)
         
         st.write(f"{tagging_options}: {BaseTagger.get_description(tagging_options)}")
         
         if tagging_options == "Standard Tagger":
             tagged_df = tag_leads(df, tag_mapping, StandardTagger)
+        elif tagging_options == "Custom Tagger #1":
+            
+            # Grab unique tags
+            all_tags = sorted({tag for tags in tag_mapping.values() for tag in tags})
+           
+            st.subheader("Set Priority for Tags")
+            st.caption("Drag to reorder tags. The first tag has the highest priority, the second tag has the second highest priority, and so on.")
+            
+            sorted_priority = sort_items(all_tags)
+
+            # only occurs if there are no tags
+            if not sorted_priority:
+                st.warning("Please input at least one mapping to continue.")
+                st.stop()
+
+            tagged_df = tag_leads(df, tag_mapping, StandardTagger)
+
 
         # hoist email, tags, name to first columns
         tagged_df = tagged_df[["email", "tags", "first_name", "last_name"] + [col for col in tagged_df.columns if col not in ["email", "tags", "first_name", "last_name"]]]

--- a/lead_tagger/__init__.py
+++ b/lead_tagger/__init__.py
@@ -1,2 +1,3 @@
 from .base import BaseTagger
 from .standard import StandardTagger
+from .custom_1 import Custom_1_Tagger

--- a/lead_tagger/base.py
+++ b/lead_tagger/base.py
@@ -19,6 +19,7 @@ class BaseTagger(ABC):
     def get_description(tagger_type: str) -> str:
         """Static method to return description based on tagger type"""
         descriptions = {
-            "Standard Tagger": "Tags leads based on the intent columns provided, adding multiple tags if multiple intents are detected.",
+            "Standard Tagger": "Tags leads based on the intent columns provided, adding multiple (unique) tags if multiple intents are detected.",
+            "Custom Tagger #1": "Standard Tagger with custom logic that ensures only 1 tag per lead, and custom priority in the case of multiple intents.",
         }
         return descriptions.get(tagger_type, "No description available.")

--- a/lead_tagger/base.py
+++ b/lead_tagger/base.py
@@ -2,9 +2,10 @@ from abc import ABC, abstractmethod
 import pandas as pd
 
 class BaseTagger(ABC):
-    def __init__(self, df: pd.DataFrame, tag_mapping: dict[str, list[str]]):
+    def __init__(self, df: pd.DataFrame, tag_mapping: dict[str, list[str]], priority_list: list[str] = None):
         self.df = df.copy()
         self.tag_mapping = tag_mapping
+        self.priority_list = priority_list if priority_list else []
 
     def apply_tags(self) -> pd.DataFrame:
         self.df["tags"] = self.df.apply(self.generate_tags, axis=1)

--- a/lead_tagger/custom_1.py
+++ b/lead_tagger/custom_1.py
@@ -1,0 +1,6 @@
+""" Custom Tagger for Jason, with custom logic that ensures only 1 tag per lead, and custom priority if multiple intents are detected. """
+from .base import BaseTagger
+import pandas as pd
+
+class Custom_1_Tagger(BaseTagger):
+    pass

--- a/lead_tagger/custom_1.py
+++ b/lead_tagger/custom_1.py
@@ -3,4 +3,13 @@ from .base import BaseTagger
 import pandas as pd
 
 class Custom_1_Tagger(BaseTagger):
-    pass
+    def generate_tags(self, row: pd.Series) -> str:
+        tags: set = set()
+
+        for col, tags_list in self.tag_mapping.items():
+            if pd.notna(row.get(col)):
+                tags.update(tags_list)
+
+        sorted_tags = sorted(tags, key=lambda x: self.priority_list.index(x))
+
+        return sorted_tags[0] if sorted_tags else ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit==1.44.1
 mailchimp_marketing==3.0.80
+streamlit-sortables==0.3.1


### PR DESCRIPTION
Implement a custom tagger class. Only one tag per lead, let client choose the priority of tags in case multiple intents detected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Custom Tagger #1" option for lead tagging, allowing users to reorder tags by priority using a draggable interface.
  - Users now receive a warning if no custom tags are available for prioritization.
- **Enhancements**
  - Updated tagger descriptions to clarify the behavior of "Standard Tagger" and describe the new "Custom Tagger #1".
- **Dependencies**
  - Added streamlit-sortables for improved drag-and-drop functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->