### PR TITLE
Hashable argument

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,9 +153,11 @@ def verify_mailchimp_credentials(api_key: str, server_prefix: str) -> bool:
     except Exception as e:
         st.error(f"An unexpected error occurred: {e}")
         return False
+    
+@st.cache_data
+def fetch_mailchimp_lists(api_key: str, server_prefix: str) -> dict[str, Any]:
+    return get_mailchimp_client(api_key, server_prefix).lists.get_all_lists()
 
-def fetch_mailchimp_lists(client: Client) -> dict[str, Any]:
-    return client.lists.get_all_lists()
 
 def send_to_mailchimp(df: pd.DataFrame, client: Client):
     """Send categorized leads to Mailchimp"""
@@ -219,7 +221,7 @@ if uploaded_file:
         st.download_button("Download CSV file", csv, "real-intent-mailchimp-leads.csv", "text/csv")
     
     elif user_choice == "Send to Mailchimp" and mailchimp_ready:
-        lists_data = fetch_mailchimp_lists(client=get_mailchimp_client(api_key, server_prefix))
+        lists_data = fetch_mailchimp_lists(api_key, server_prefix)
         if lists_data:
             audience_options = {lst['name']: lst['id'] for lst in lists_data['lists']}
             list_name = st.selectbox("Select a List", list(audience_options.keys()))


### PR DESCRIPTION
Modify fetch lists to take in a hashable argument, so it can be cached. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way Mailchimp lists are fetched by updating the method to use API credentials directly and caching the results for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->